### PR TITLE
Add bs-elm

### DIFF
--- a/sources.json
+++ b/sources.json
@@ -236,6 +236,11 @@
       "keywords": ["async", "utilities"],
       "comment": "Inadequate readme"
     },
+    "bs-elm": {
+      "category": "binding",
+      "platforms": ["browser"],
+      "keywords": ["elm"]
+    },
     "bs-enzyme": {
       "category": "binding",
       "platforms": ["node"],

--- a/sources.json
+++ b/sources.json
@@ -239,7 +239,7 @@
     "bs-elm": {
       "category": "binding",
       "platforms": ["browser"],
-      "keywords": ["elm"]
+      "keywords": ["development tools"]
     },
     "bs-enzyme": {
       "category": "binding",


### PR DESCRIPTION
Hey, this is adding (`bs-elm`)[https://github.com/jaredramirez/bs-elm] to redex.

I added the new keyword `elm`, because none of the keywords on the redex homepage really fit.