### PR TITLE
Add typed_i18n and dependency binding

### DIFF
--- a/sources.json
+++ b/sources.json
@@ -82,6 +82,11 @@
       "keywords": ["opengl", "graphics"],
       "comment": "Inadequate readme, missing license"
     },
+    "@kogai/typed_i18n": {
+      "category": "tool",
+      "platforms": ["node"],
+      "keywords": ["i18n"]
+    },
     "@nebuta/bs-jquery": {
       "category": "binding",
       "flags": ["neglected"],
@@ -206,6 +211,11 @@
       "keywords": ["css"],
       "comment": "Inadequate readme"
     },
+    "bs-cmdliner": {
+      "category": "binding",
+      "platforms": ["node"],
+      "keywords": ["cli"]
+    },
     "bs-dataloader": {
       "category": "binding",
       "flags": ["neglected"],
@@ -236,6 +246,11 @@
       "category": "binding",
       "platforms": ["browser"],
       "keywords": ["react", "ui"]
+    },
+    "bs-easy-format": {
+      "category": "binding",
+      "platforms": ["any"],
+      "keywords": ["format"]
     },
     "bs-effects": {
       "category": "library",


### PR DESCRIPTION
It would be an honor to register my tool which written by ReasonML to Redex 🙏 
At the same time, I'd like to add two bindings which my tool depends on.