### PR TITLE
Add bs-validation, bs-sql-composer and bs-sql-common

### DIFF
--- a/sources.json
+++ b/sources.json
@@ -550,6 +550,16 @@
       "keywords": ["cloud service api"],
       "comment": "Inadequate readme"
     },
+    "bs-sql-common": {
+      "category": "sql",
+      "platforms": ["node"],
+      "keywords": ["sql","database"]
+    },
+    "bs-sql-composer": {
+      "category": "sql",
+      "platforms": ["node"],
+      "keywords": ["sql", "database"]
+    },
     "bs-svg-attachment": {
       "category": "binding",
       "platforms": ["browser"],

--- a/sources.json
+++ b/sources.json
@@ -551,12 +551,12 @@
       "comment": "Inadequate readme"
     },
     "bs-sql-common": {
-      "category": "sql",
+      "category": "library",
       "platforms": ["node"],
       "keywords": ["sql","database"]
     },
     "bs-sql-composer": {
-      "category": "sql",
+      "category": "library",
       "platforms": ["node"],
       "keywords": ["sql", "database"]
     },

--- a/sources.json
+++ b/sources.json
@@ -565,6 +565,11 @@
       "platforms": ["browser"],
       "keywords": ["svg", "graphics"]
     },
+    "bs-validation": {
+      "category": "library",
+      "platforms": ["node"],
+      "keywords": ["validation"]
+    },
     "bs-vscode": {
       "category": "binding",
       "flags": ["neglected"],

--- a/sources.json
+++ b/sources.json
@@ -392,6 +392,11 @@
       "platforms": ["node"],
       "keywords": ["sql", "database"]
     },
+    "bs-mysql2": {
+      "category": "binding",
+      "platforms": ["node"],
+      "keywords": ["sql", "database"]
+    },
     "bs-next": {
       "category": "binding",
       "platforms": ["node"],


### PR DESCRIPTION
I'm not sure why or how `bs-sql-composer` and `bs-sql-common` are not in the sources list, but I only meant to add `bs-validation`.   However, it seems that both `bs-sql-composer` and `bs-sql-common` are already listed on the redex.  

`bs-validation` is an implementation of the [Folktale/Validation][folktale-validation] Applicative.

[folktale-validation][http://folktale.origamitower.com/api/v2.1.0/en/folktale.validation.html]