### PR TITLE
Add bs-typed-array to sources.json

### DIFF
--- a/sources.json
+++ b/sources.json
@@ -606,6 +606,11 @@
       "platforms": ["browser"],
       "keywords": ["svg", "graphics"]
     },
+    "bs-typed-array": {
+      "category": "binding",
+      "platforms": ["browser", "node"],
+      "keywords": ["standard library"]
+    },
     "bs-validation": {
       "category": "library",
       "platforms": ["any"],


### PR DESCRIPTION
Added bindings to the [TypedArray builtins](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Typed_arrays), the bindings are pretty low level. Not really certain on the key words, feel free to change if you have any suggestions.