### PR TITLE
Add bs-semantic-ui-react to sources.json

### DIFF
--- a/sources.json
+++ b/sources.json
@@ -106,6 +106,11 @@
       "platforms": ["node"],
       "keywords": ["testing"]
     },
+    "@voodoos/bs-semantic-ui-react": {
+      "category": "library",
+      "platforms": ["node"],
+      "keywords": ["testing"]
+    },
     "add-reason": {
       "category": "tool",
       "platforms": ["node"],
@@ -1333,6 +1338,12 @@
       "platforms": ["browser", "node"],
       "keywords": ["react"],
       "comment": "Missing description, homepage url, issues url, installation instructions"
+    },
+    "voodoos/bs-semantic-ui-react": {
+      "repository": "github:voodoos/bs-semantic-ui-react",
+      "category": "bindings",
+      "platforms": ["browser"],
+      "keywords": ["semantic-ui", "react", "ui"]
     }
   },
 


### PR DESCRIPTION
I have started to write a set of bindings for the [Semantic Ui React components](https://react.semantic-ui.com).
These bindings are in an very early stage but I hope they are easy to scale up.

The Semantic Ui components are numerous and accept lots of props, that's why I think it's still a good idea to reference it on Redex as people could be interested in using / completing them.

I hope they are not to badly written, it is my first Reason project and I still have a lot to learn...