### PR TITLE
Add bs-recharts package with Recharts bindings

### DIFF
--- a/sources.json
+++ b/sources.json
@@ -1001,6 +1001,11 @@
       "category": "library",
       "platforms": ["browser", "node"],
       "keywords": ["async"]
+    },
+    "bs-recharts": {
+      "category": "binding",
+      "platforms": ["browser"],
+      "keywords": ["react", "ui"]
     }
   },
 
@@ -1366,7 +1371,13 @@
       "category": "binding",
       "platforms": ["browser"],
       "keywords": ["react", "ui"]
-     }
+     },
+    "ahrefs/bs-recharts": {
+      "repository": "github:ahrefs/bs-recharts",
+      "category": "binding",
+      "platforms": ["browser"],
+      "keywords": ["react", "ui"]
+    }
   },
 
   "prematurely-published": {


### PR DESCRIPTION
This is the package with bindings for Reactstrap. Currently, there are just some bindings that we are using in our project. We are adding them as we go.