### PR TITLE
add bs-jszip

### DIFF
--- a/sources.json
+++ b/sources.json
@@ -1366,17 +1366,17 @@
       "keywords": ["react"],
       "comment": "Missing description, homepage url, issues url, installation instructions"
     },
+    "voodoos/bs-jszip": {
+      "repository": "github:voodoos/bs-jszip",
+      "category": "binding",
+      "platforms": ["browser", "node"],
+      "keywords": ["utilities"]
+    },
     "voodoos/bs-semantic-ui-react": {
       "repository": "github:voodoos/bs-semantic-ui-react",
       "category": "binding",
       "platforms": ["browser"],
       "keywords": ["react", "ui"]
-     },
-    "voodoos/bs-jszip": {
-      "repository": "github:voodoos/bs-jszip",
-      "category": "binding",
-      "platforms": ["browser"],
-      "keywords": ["utilities", "filesystem"]
      }
   },
 

--- a/sources.json
+++ b/sources.json
@@ -1371,6 +1371,12 @@
       "category": "binding",
       "platforms": ["browser"],
       "keywords": ["react", "ui"]
+     },
+    "voodoos/bs-jszip": {
+      "repository": "github:voodoos/bs-jszip",
+      "category": "binding",
+      "platforms": ["browser"],
+      "keywords": ["utilities", "filesystem"]
      }
   },
 


### PR DESCRIPTION
For my project [ElpIDE](https://github.com/voodoos/ElpIDE) I needed a way to manipulate zip files so I created these JSZip bindings. 
They are not complete (but almost) and not fully tested but advanced enough to be used in most cases.

There are also bindings for Blob inside this repository (needed by JSZip) and I will probably make them separate soon.