### PR TITLE
Add bs-nonempty

### DIFF
--- a/sources.json
+++ b/sources.json
@@ -506,6 +506,11 @@
       "platforms": ["node"],
       "keywords": ["cli", "utilities"]
     },
+    "bs-nonempty": {
+      "category": "library",
+      "platforms": ["any"],
+      "keywords": ["utilities", "collections"]
+    },
     "bs-nprogress": {
       "category": "binding",
       "platforms": ["browser"],


### PR DESCRIPTION
`bs-nonempty` is a library ([on npm](https://www.npmjs.com/package/bs-nonempty), [on Github](https://github.com/mlms13/bs-nonempty)) for working with collections that are guaranteed to contain at least one item. It includes implementations for working with nonempty Arrays and nonempty Lists.

Inspired by:
  - [List.Nonempty](https://package.elm-lang.org/packages/mgold/elm-nonempty-list/latest/) in Elm
  - [purescript-nonempty](https://github.com/purescript/purescript-nonempty)
  - [thx.nel](https://github.com/fponticelli/thx.core/blob/master/src/thx/Nel.hx) in the `thx` library for Haxe