### PR TITLE
Add bs-priority-queue to sources.json

### DIFF
--- a/sources.json
+++ b/sources.json
@@ -578,6 +578,11 @@
       "platforms": ["browser", "node"],
       "keywords": ["testing"]
     },
+    "bs-priority-queue": {
+      "category": "binding",
+      "platforms": ["browser", "node"],
+      "keywords": ["collections"]
+    },
     "bs-promise-monad": {
       "category": "library",
       "platforms": ["browser", "node"],


### PR DESCRIPTION
Couldn't find good priority queue/heap bindings, so I just made some for tinyqueue.