### PR TITLE
Add up to date bs-react-helmet (bs bindings for React Helmet)

### DIFF
--- a/sources.json
+++ b/sources.json
@@ -144,8 +144,8 @@
     },
     "@moox/bs-react-helmet": {
       "category": "binding",
-      "platforms": ["browser", "node"],
-      "keywords": ["react", "head", "react-helmet"]
+      "platforms": ["browser"],
+      "keywords": ["react"]
     },
     "@nebuta/bs-jquery": {
       "category": "binding",

--- a/sources.json
+++ b/sources.json
@@ -142,6 +142,11 @@
       "platforms": ["browser", "node"],
       "keywords": ["date/time manipulation"]
     },
+    "@moox/bs-react-helmet": {
+      "category": "binding",
+      "platforms": ["browser", "node"],
+      "keywords": ["react", "head", "react-helmet"]
+    },
     "@nebuta/bs-jquery": {
       "category": "binding",
       "flags": ["neglected"],

--- a/sources.json
+++ b/sources.json
@@ -144,7 +144,7 @@
     },
     "@moox/bs-react-helmet": {
       "category": "binding",
-      "platforms": ["browser"],
+      "platforms": ["browser", "node"],
       "keywords": ["react"]
     },
     "@nebuta/bs-jquery": {


### PR DESCRIPTION
Because `bs-react-helmet` is neglected and this one is not.