### PR TITLE
Add reductive-dev-tools 

### DIFF
--- a/sources.json
+++ b/sources.json
@@ -1098,6 +1098,11 @@
       "keywords": ["react", "state management"],
       "comment": "Missing repository url, installation instructions"
     },
+    "reductive-dev-tools": {
+      "category": "tool",
+      "platforms": ["browser"],
+      "keywords": ["development tools"]
+    },
     "refmterr": {
       "category": "tool",
       "platforms": ["native"],
@@ -1168,11 +1173,6 @@
     "upgrade-reason-syntax": {
       "category": "tool",
       "platforms": ["node"],
-      "keywords": ["development tools"]
-    },
-    "reductive-dev-tools": {
-      "category": "tool",
-      "platforms": ["browser"],
       "keywords": ["development tools"]
     }
   },

--- a/sources.json
+++ b/sources.json
@@ -1169,6 +1169,11 @@
       "category": "tool",
       "platforms": ["node"],
       "keywords": ["development tools"]
+    },
+    "reductive-dev-tools": {
+      "category": "tool",
+      "platforms": ["browser"],
+      "keywords": ["development tools"]
     }
   },
 


### PR DESCRIPTION
Released an integration of reductive with [redux-devtools-extension](https://github.com/zalmoxisus/redux-devtools-extension)

State is described at 
[Supported DevTools Features](https://github.com/ambientlight/reductive-dev-tools#supported-devtools-features)

https://github.com/ambientlight/reductive-dev-tools
https://www.npmjs.com/package/reductive-dev-tools