### PR TITLE
Add bs-winston and bs-winston-cloudwatch

### DIFF
--- a/sources.json
+++ b/sources.json
@@ -798,6 +798,16 @@
       "platforms": ["browser"],
       "keywords": ["utilities"]
     },
+    "bs-winston": {
+      "category": "binding",
+      "platforms": ["node"],
+      "keywords": ["winston", "logging"]
+    },
+    "bs-winston-cloudwatch": {
+      "category": "binding",
+      "platforms": ["node"],
+      "keywords": ["winston", "cloudwatch", "transporter", "logging"]
+    },
     "bs-ws": {
       "category": "binding",
       "platforms": ["node"],

--- a/sources.json
+++ b/sources.json
@@ -801,12 +801,12 @@
     "bs-winston": {
       "category": "binding",
       "platforms": ["node"],
-      "keywords": ["winston", "logging"]
+      "keywords": ["logging"]
     },
     "bs-winston-cloudwatch": {
       "category": "binding",
       "platforms": ["node"],
-      "keywords": ["winston", "cloudwatch", "transporter", "logging"]
+      "keywords": ["logging"]
     },
     "bs-ws": {
       "category": "binding",


### PR DESCRIPTION
Bindings for winstonjs logger. MIT license. Sources hosted at github.