### PR TITLE
Add bs-tinycolor

### DIFF
--- a/sources.json
+++ b/sources.json
@@ -774,6 +774,11 @@
       "platforms": ["node"],
       "keywords": ["testing"]
     },
+    "bs-tinycolor": {
+      "category": "binding",
+      "platforms": ["browser", "node"],
+      "keywords": ["graphics", "utilities"]
+    },
     "bs-validation": {
       "category": "library",
       "platforms": ["any"],


### PR DESCRIPTION
[bs-tinycolor](https://github.com/mikaello/bs-tinycolor) are bindings for [TinyColor](https://github.com/TypeCtrl/tinycolor) (color manipulation and conversion)