### PR TITLE
Added ReasonQL: Type-safe and simple GraphQL client for ReasonML developers. 

### DIFF
--- a/sources.json
+++ b/sources.json
@@ -166,6 +166,11 @@
       "platforms": ["node"],
       "keywords": ["platform api"]
     },
+    "@reasonql/core": {
+      "category": "library",
+      "platforms": ["browser", "node"],
+      "keywords": ["graphql", "data fetching"]
+    },
     "@stroiman/respect": {
       "category": "library",
       "platforms": ["node"],


### PR DESCRIPTION
Hello.

I've created a simple GraphQL library for ReasonML and want to register it. 

The project is here: https://github.com/sainthkh/reasonql

**Some Questions**
1. As the compiler of this project is written in JavaScript, I didn't add the compiler to the list. Or should I?
2. As I used Lerna to manage the compiler and core library, the name starts with "@reasonql" but it's published at npm and reasonql isn't my user name. Is it OK?