### PR TITLE
Add GeoReason

### DIFF
--- a/sources.json
+++ b/sources.json
@@ -971,6 +971,11 @@
       "keywords": ["code generation"],
       "comment": "Inadequate/misleading readme"
     },
+    "geo-reason": {
+      "category": "library",
+      "platforms": ["browser", "node"],
+      "keywords": ["maps"]
+    },
     "gimme-reason": {
       "category": "tool",
       "platforms": ["node"],


### PR DESCRIPTION
GeoReason ([Github](https://github.com/homebay/geo-reason), [npm](https://www.npmjs.com/package/geo-reason)) is a library for working with [GeoJSON](https://tools.ietf.org/html/rfc7946) data in Reason. It builds many of the rules from the spec into the type system and provides functions for safely decoding JSON and encoding Reason data into correct GeoJSON.