### PR TITLE
Add bs-big.js

### DIFF
--- a/sources.json
+++ b/sources.json
@@ -341,6 +341,11 @@
       "keywords": ["standard library", "collections", "utilities"],
       "comment": "Inadequate readme"
     },
+    "bs-big.js": {
+      "category": "binding",
+      "platforms": ["browser", "node"],
+      "keywords": ["math", "utilities"]
+    },
     "bs-bn.js": {
       "category": "binding",
       "platforms": ["browser", "node"],


### PR DESCRIPTION
[big.js](https://github.com/MikeMcl/big.js/) is a library for arbitrary precision decimal arithmetic. [bs-big.js](https://github.com/alexchang8/bs-big.js) provides bindings to all methods of the library.