### PR TITLE
Add bs-decode

### DIFF
--- a/sources.json
+++ b/sources.json
@@ -409,6 +409,11 @@
       "platforms": ["browser", "node"],
       "keywords": ["utilities"]
     },
+    "bs-decode": {
+      "category": "library",
+      "platforms": ["browser", "node"],
+      "keywords": ["json", "data serialization"]
+    },
     "bs-director": {
       "category": "binding",
       "flags": ["neglected"],


### PR DESCRIPTION
bs-decode ([Github](https://github.com/mlms13/bs-decode), [npm](https://www.npmjs.com/package/bs-decode)) provides composable JSON decoders that collect structured, extensible errors when failures are encountered.