### PR TITLE
Add @leeor/bs-argon2

### DIFF
--- a/sources.json
+++ b/sources.json
@@ -137,6 +137,11 @@
       "platforms": ["browser"],
       "keywords": ["platform api"]
     },
+    "@leeor/bs-argon2": {
+      "category": "binding",
+      "platforms": ["node"],
+      "keywords": ["cryptography"]
+    },
     "@mobily/re-date": {
       "category": "library",
       "platforms": ["browser", "node"],


### PR DESCRIPTION
Argon2 is a password hashing algorithm. This module contains BS bindings for using it in ReasonML/BS.

[Wikipedia entry](https://en.wikipedia.org/wiki/Argon2)
[node-argon2](https://github.com/ranisalt/node-argon2)