### PR TITLE
Add reason-react-native and reason-react-native-maps

### DIFF
--- a/sources.json
+++ b/sources.json
@@ -1164,6 +1164,16 @@
       "platforms": ["browser"],
       "keywords": ["react"]
     },
+    "reason-react-native": {
+      "category": "binding",
+      "platforms": ["node"],
+      "keywords": ["react", "react-native", "ui"]
+    },
+    "reason-react-native-maps": {
+      "category": "binding",
+      "platforms": ["node"],
+      "keywords": ["react-native", "react-native-maps", "maps"]
+    },
     "reason-react-native-scripts": {
       "category": "tool",
       "flags": ["neglected"],

--- a/sources.json
+++ b/sources.json
@@ -1172,7 +1172,7 @@
     "reason-react-native-maps": {
       "category": "binding",
       "platforms": ["node"],
-      "keywords": ["react-native", "react-native-maps", "maps"]
+      "keywords": ["react-native", "maps"]
     },
     "reason-react-native-scripts": {
       "category": "tool",


### PR DESCRIPTION
Zero-cost bindings to React Native, originally developed within the `bs-react-native` monorepo were released as `reason-react-native` (repository was renamed as well, with a copy keeping the old name). They were not previously released as an npm package and not referenced here.

I have also prepared bindings to `react-native-maps` and I would like to add those as well.