### PR TITLE
Add @reason-react-native/netinfo

### DIFF
--- a/sources.json
+++ b/sources.json
@@ -176,6 +176,11 @@
       "platforms": ["node"],
       "keywords": ["platform api"]
     },
+    "@reason-react-native/netinfo": {
+      "category": "binding",
+      "platforms": ["node"],
+      "keywords": ["react-native"]
+    },
     "@reasonql/core": {
       "category": "library",
       "platforms": ["browser", "node"],


### PR DESCRIPTION
`NetInfo` has been removed from RN as of version 0.60 and moved into a community repository.

This package provides bindings to the community package.