### PR TITLE
add bs-jest-date-mock

### DIFF
--- a/sources.json
+++ b/sources.json
@@ -548,6 +548,11 @@
       "platforms": ["browser", "node"],
       "keywords": ["string manipulation", "utilities"]
     },
+    "bs-jest-date-mock": {
+      "category": "binding",
+      "platforms": ["node"],
+      "keywords": ["testing", "date/time manipulation"]
+    },
     "bs-jest-dom": {
       "category": "binding",
       "platforms": ["node"],


### PR DESCRIPTION
[bs-jest-date-mock](https://github.com/mikaello/bs-jest-date-mock) is bindings for [jest-date-mock](https://github.com/hustcc/jest-date-mock).

It adds the possibility to change what `Js.Date` return, and can be used to help testing date based libraries.