### PR TITLE
add bs-cron

### DIFF
--- a/sources.json
+++ b/sources.json
@@ -373,6 +373,11 @@
       "platforms": ["node"],
       "keywords": ["utilities"]
     },
+    "bs-cron": {
+      "category": "binding",
+      "platforms": ["node"],
+      "keywords": ["utilities"]
+    },
     "bs-css": {
       "category": "binding",
       "platforms": ["browser"],


### PR DESCRIPTION
[bs-cron](https://github.com/mikaello/bs-node-cron) is bindings for [node-cron / cron](https://github.com/kelektiv/node-cron) (I have tried to use same naming as original repo, using `bs-node-cron` as repo name and `bs-cron` as package name).

node-cron a library that gives the user the ability to schedule (recurring) function invocations with cron-syntax or a Js.Date-object. Scheduling is implemented with `setTimeout` and `Js.Date`.