### PR TITLE
Add published libs from the Relude family

### DIFF
--- a/sources.json
+++ b/sources.json
@@ -1345,6 +1345,26 @@
       "platforms": ["browser", "node"],
       "keywords": ["utilities", "standard library", "collections"]
     },
+    "relude-eon": {
+      "category": "library",
+      "platforms": ["browser", "node"],
+      "keywords": ["date/time manipulation"]
+    },
+    "relude-fetch": {
+      "category": "library",
+      "platofrms": ["browser", "node"],
+      "keywords": ["data fetching"]
+    },
+    "relude-parse": {
+      "category": "library",
+      "platforms": ["browser", "node"],
+      "keywords": ["parsing"]
+    },
+    "relude-reason-react": {
+      "category": "library",
+      "platforms": ["browser"],
+      "keywords": ["react", "state management", "ui"]
+    },
     "rex-json": {
       "category": "library",
       "platforms": ["any"],

--- a/sources.json
+++ b/sources.json
@@ -1352,7 +1352,7 @@
     },
     "relude-fetch": {
       "category": "library",
-      "platofrms": ["browser", "node"],
+      "platforms": ["browser", "node"],
       "keywords": ["data fetching"]
     },
     "relude-parse": {


### PR DESCRIPTION
The Relude family of libraries is growing, and I want to keep Redex up-to-date. We now have:

- `relude-eon` for working with dates and times
- `relude-fetch` as a higher-level, opinionated layer on top of `bs-fetch`
- `relude-parse` a monadic string parsing library
- `relude-reason-react` for managing state and effects in Reason React

I just read through the Redex publishing guidelines again, and I noticed that a couple of the READMEs here are over the 10kb limit. If that's an issue, I can look into moving some of the bigger blocks of documentation and examples out of the READMEs and into separate doc pages.