### PR TITLE
Add bs-react-swipeable-views to redex 

### DIFF
--- a/sources.json
+++ b/sources.json
@@ -910,6 +910,11 @@
       "platforms": ["browser"],
       "keywords": ["svg", "graphics"]
     },
+    "bs-react-swipeable-views": {
+      "category": "binding"",
+      "platforms": ["browser"],
+      "keywords": ["ui", "react"]
+    },
     "bs-tape": {
       "category": "binding",
       "platforms": ["node"],

--- a/sources.json
+++ b/sources.json
@@ -911,7 +911,7 @@
       "keywords": ["svg", "graphics"]
     },
     "bs-react-swipeable-views": {
-      "category": "binding"",
+      "category": "binding",
       "platforms": ["browser"],
       "keywords": ["ui", "react"]
     },


### PR DESCRIPTION
I think [bs-react-swipeable-views](https://github.com/SindreSvendby/bs-react-swipeable-views) follow all the details I found in the [documentation](https://redex.github.io/publish) and are ready to be published to redex