### PR TITLE
Add bs-node-config

### DIFF
--- a/sources.json
+++ b/sources.json
@@ -281,6 +281,11 @@
       "platforms": ["node"],
       "keywords": ["testing"]
     },
+    "@veikkaus/re-node-config": {
+      "category": "library",
+      "platforms": ["node"],
+      "keywords": ["configuration"]
+    },
     "@wokalski/vow": {
       "category": "library",
       "platforms": ["browser", "node"],


### PR DESCRIPTION
This library (https://www.npmjs.com/package/bs-node-config) is similar to node-config (http://lorenwest.github.io/node-config/) , config library written for node, but bs-node-config is written completely in ReasonML (doesn't use or depend on node-config). Features are similar but partially different too, e.g. strong validation of config parameters and json parsing of environment variable values are included. Node is the only viable platform because depends on nodejs fs api.