### PR TITLE
Add @ambientlight/bs-rx

### DIFF
--- a/sources.json
+++ b/sources.json
@@ -20,6 +20,11 @@
       "platforms": ["browser"],
       "keywords": ["react", "ui"]
     },
+    "@ambientlight/bs-rx": {
+      "category": "binding",
+      "platforms": ["browser"],
+      "keywords": ["async", "utilities", "reactive programming"]
+    },
     "@astrada/bs-react-fela": {
       "category": "binding",
       "platforms": ["browser"],


### PR DESCRIPTION
https://github.com/ambientlight/bs-rx
https://www.npmjs.com/package/@ambientlight/bs-rx

Bucklescript bindings for [rxjs v7(alpha)](https://github.com/ReactiveX/rxjs)  
Most functionality is available, while ajax / fetch / websocket apis are not yet done. Coverage available for most implemented operators and static observable creators via github actions CI.
Also auto-generated documentation via `bsdoc` is available. (Refer to [documentation](https://ambientlight.github.io/bs-rx))

Is regex going to look into `package.json` `docs` field for documentation link?