### PR TITLE
Add bs-pixi

### DIFF
--- a/sources.json
+++ b/sources.json
@@ -766,6 +766,11 @@
       "keywords": ["express", "routing"],
       "comment": "Missing installation instructions"
     },
+    "bs-pixi": {
+      "category": "binding",
+      "platforms": ["browser"],
+      "keywords": ["opengl", "graphics"]
+    },
     "bs-pixl-xml": {
       "category": "binding",
       "platforms": ["node", "browser"],


### PR DESCRIPTION
buckleScript bindings for PIXI.js v5.  

 some extensive bindings done for pixi.js, not fully complete yet, as pixi has gigantic set of apis there, but it covers essential usecases, can be a starting point for anybody playing with 2d

https://github.com/ambientlight/bs-pixi
https://www.npmjs.com/package/bs-pixi

