### PR TITLE
Add @rejs/re-future

### DIFF
--- a/sources.json
+++ b/sources.json
@@ -206,6 +206,11 @@
       "platforms": ["browser", "node"],
       "keywords": ["graphql", "data fetching"]
     },
+    "@rejs/re-future": {
+      "category": "library",
+      "platforms": ["browser", "node"],
+      "keywords": ["async"]
+    },
     "@ristostevcev/bs-callbag-basics": {
       "category": "binding",
       "platforms": ["browser", "node"],


### PR DESCRIPTION
This is a library containing Future and ResultFuture monadic modules to use instead of Js.Promise . There are already other libraries providing the same concept with similar features, however this is a unique implementation, not a fork or a copy job. Special focus has been given to provide wide variety of utility functions and to thorough testing and performance testing.