### PR TITLE
Remove neglected tag from reductive

### DIFF
--- a/sources.json
+++ b/sources.json
@@ -1367,10 +1367,8 @@
     },
     "reductive": {
       "category": "library",
-      "flags": ["neglected"],
       "platforms": ["browser", "node"],
-      "keywords": ["react", "state management"],
-      "comment": "Missing repository url, installation instructions"
+      "keywords": ["react", "state management"]
     },
     "reductive-dev-tools": {
       "category": "tool",


### PR DESCRIPTION
The original reasons (per blame) for the neglected tag (no installation instructions, no repo URL) appear to no longer apply. Reductive's README has [installation instructions](https://redex.github.io/package/reductive) and redex clearly links the repository URL correctly for this package.