### PR TITLE
correct a keyword typo

### DIFF
--- a/sources.json
+++ b/sources.json
@@ -1151,7 +1151,7 @@
     "re-discord": {
       "category": "library",
       "platforms": ["native"],
-      "keywords": ["platform-api"]
+      "keywords": ["platform api"]
     },
     "re-classnames": {
       "category": "library",


### PR DESCRIPTION
correct one of the keywords of the "re-discord" package, from "platform-api" to "platform api"